### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ struct User: Codable {
     @PromisedBool var isActive: Bool       // "yes", 1, "false", etc.
     @PromisedString var nickname: String   // 123 → "123"
     @PromisedDouble var rating: Double     // "4.5" → 4.5
-
-    @PromisedInt(fallback: -1) var score: Int
 }
 ```
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -68,8 +68,6 @@ struct User: Codable {
     @PromisedBool var isActive: Bool       // "yes", 1, "false" 등
     @PromisedString var nickname: String   // 123 → "123"
     @PromisedDouble var rating: Double     // "4.5" → 4.5
-
-    @PromisedInt(fallback: -1) var score: Int
 }
 ```
 
@@ -89,10 +87,10 @@ struct User: Codable {
 
 | 래퍼                  | 지원되는 입력 형식                                | 기본 fallback 값   |
 |-----------------------|--------------------------------------------------|--------------------|
-| `@PromisedInt`        | `Int`, `"123"`, `123.4`, `true` 등               | `0`                |
+| `@PromisedInt`        | `Int`, `"123"`, `123.4`, `true` 등               | `-1`                |
 | `@PromisedBool`       | `true`, `"yes"`, `1`, `"false"` 등               | `false`            |
 | `@PromisedString`     | `"문자열"`, `123`, `true` 등                     | `""`               |
-| `@PromisedDouble`     | `123.45`, `"123"`, `true` 등                     | `0.0`              |
+| `@PromisedDouble`     | `123.45`, `"123"`, `true` 등                     | `-1.0`              |
 | `@PromisedOptional*`  | 위와 동일, 실패 시 `nil` 반환                    | `nil`              |
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README and README_KR to reflect changes in the default fallback values for `@PromisedInt` and `@PromisedDouble` property wrappers.
  - Simplified example usage in documentation by removing explicit fallback values, aligning examples with new defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->